### PR TITLE
fix for iOS13

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "krzyzanowskim/CryptoSwift"
-github "ishkawa/APIKit" ~> 3.1
+github "ishkawa/APIKit" ~> 5.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,2 @@
-github "antitypical/Result" "3.2.4"
-github "ishkawa/APIKit" "3.2.1"
-github "krzyzanowskim/CryptoSwift" "0.12.0"
+github "ishkawa/APIKit" "5.0.0"
+github "krzyzanowskim/CryptoSwift" "1.1.0"

--- a/NemSwift.xcodeproj/project.pbxproj
+++ b/NemSwift.xcodeproj/project.pbxproj
@@ -63,7 +63,6 @@
 		5F37B0B720FAAD05002315C1 /* ed25519_sha3_512.c in Sources */ = {isa = PBXBuildFile; fileRef = 3E31D1231FBC2119006CFB33 /* ed25519_sha3_512.c */; };
 		5F37B0B820FAAD05002315C1 /* NemSwiftConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4F51B82055BC6300EE4F2C /* NemSwiftConfiguration.swift */; };
 		5F37B0BF20FAAE76002315C1 /* APIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9CA6A01FC2D6A30096808F /* APIKit.framework */; };
-		5F37B0C020FAAE76002315C1 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9CA6A31FC2D7420096808F /* Result.framework */; };
 		5F37B0C220FAAE76002315C1 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E31D1381FBC452A006CFB33 /* CryptoSwift.framework */; };
 		5F37B0C720FAE232002315C1 /* ed25519_sha3_512.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E31D1241FBC2119006CFB33 /* ed25519_sha3_512.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5F37B0C820FAE603002315C1 /* ed25519.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E31CFC51FBC18D8006CFB33 /* ed25519.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -74,7 +73,6 @@
 		5F37B0CD20FBDB89002315C1 /* AddressTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4F51B1205482F100EE4F2C /* AddressTest.swift */; };
 		5F37B0D020FBDD0D002315C1 /* AccountTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4F51B3205485A400EE4F2C /* AccountTest.swift */; };
 		5F37B0D420FBDF9D002315C1 /* APIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9CA6A01FC2D6A30096808F /* APIKit.framework */; };
-		5F37B0D520FBDF9D002315C1 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E9CA6A31FC2D7420096808F /* Result.framework */; };
 		5F37B0D720FBDF9D002315C1 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E31D1381FBC452A006CFB33 /* CryptoSwift.framework */; };
 		5F37B0DA20FBE2EB002315C1 /* NemSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F37B03720FAABE4002315C1 /* NemSwift.framework */; };
 		5F37B0DB20FBE2EB002315C1 /* NemSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5F37B03720FAABE4002315C1 /* NemSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -181,7 +179,6 @@
 		3E633BE51FC574A800D5DCD3 /* TransferTransactionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferTransactionHelper.swift; sourceTree = "<group>"; };
 		3E633BE71FC57DD800D5DCD3 /* RequestAnnounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAnnounce.swift; sourceTree = "<group>"; };
 		3E9CA6A01FC2D6A30096808F /* APIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = APIKit.framework; path = Carthage/Build/iOS/APIKit.framework; sourceTree = "<group>"; };
-		3E9CA6A31FC2D7420096808F /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/iOS/Result.framework; sourceTree = "<group>"; };
 		3E9CA6A51FC2D9440096808F /* NISRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NISRequest.swift; sourceTree = "<group>"; };
 		3E9CA6A71FC2D9EB0096808F /* DecodableDataParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodableDataParser.swift; sourceTree = "<group>"; };
 		3E9CA6AA1FC2DD5B0096808F /* AccountInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfo.swift; sourceTree = "<group>"; };
@@ -247,7 +244,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				5F37B0BF20FAAE76002315C1 /* APIKit.framework in Frameworks */,
-				5F37B0C020FAAE76002315C1 /* Result.framework in Frameworks */,
 				5F37B0C220FAAE76002315C1 /* CryptoSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -257,7 +253,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				5F37B0D420FBDF9D002315C1 /* APIKit.framework in Frameworks */,
-				5F37B0D520FBDF9D002315C1 /* Result.framework in Frameworks */,
 				5F37B0D720FBDF9D002315C1 /* CryptoSwift.framework in Frameworks */,
 				5F37B04020FAABE4002315C1 /* NemSwift.framework in Frameworks */,
 			);
@@ -429,7 +424,6 @@
 		3E31D1371FBC4529006CFB33 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3E9CA6A31FC2D7420096808F /* Result.framework */,
 				3E9CA6A01FC2D6A30096808F /* APIKit.framework */,
 				3E31D1381FBC452A006CFB33 /* CryptoSwift.framework */,
 			);
@@ -691,13 +685,12 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/CryptoSwift.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/APIKit.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/Result.framework",
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/NemSwift.xcodeproj/xcshareddata/xcschemes/NemSwift.xcscheme
+++ b/NemSwift.xcodeproj/xcshareddata/xcschemes/NemSwift.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5F37B03620FAABE4002315C1"
+            BuildableName = "NemSwift.framework"
+            BlueprintName = "NemSwift"
+            ReferencedContainer = "container:NemSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5F37B03620FAABE4002315C1"
-            BuildableName = "NemSwift.framework"
-            BlueprintName = "NemSwift"
-            ReferencedContainer = "container:NemSwift.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:NemSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/NemSwift/Sources/RIPEMD-160/NSData+HexString.swift
+++ b/NemSwift/Sources/RIPEMD-160/NSData+HexString.swift
@@ -1,25 +1,6 @@
 import Foundation
 
 extension Data {
-    /*
-    public func toHexString () -> String {
-        let sha256description = self.description as String
-        
-        // TODO: more elegant way to convert NSData to a hex string
-        
-        var result: String = ""
-
-        for char in sha256description.characters {
-            switch char {
-            case "0", "1", "2", "3", "4", "5", "6", "7","8","9", "a", "b", "c", "d", "e", "f":
-                result.append(char)
-            default:
-                result += String("")
-            }
-        }
-        
-        return result
-    }*/
 
     public static func fromHexString (_ string: String) -> Data {
         // Based on: http://stackoverflow.com/a/2505561/313633
@@ -44,25 +25,6 @@ extension Data {
 }
 
 extension NSData {
-    
-    public func toHexString () -> String {
-        let sha256description = self.description as String
-        
-        // TODO: more elegant way to convert NSData to a hex string
-        
-        var result: String = ""
-        
-        for char in sha256description {
-            switch char {
-            case "0", "1", "2", "3", "4", "5", "6", "7","8","9", "a", "b", "c", "d", "e", "f":
-                result.append(char)
-            default:
-                result += String("")
-            }
-        }
-        
-        return result
-    }
     
     public static func fromHexString (_ string: String) -> NSData {
         // Based on: http://stackoverflow.com/a/2505561/313633

--- a/NemSwift/Sources/RIPEMD-160/RIPEMD.swift
+++ b/NemSwift/Sources/RIPEMD-160/RIPEMD.swift
@@ -75,7 +75,7 @@ public struct RIPEMD {
     
     // Returns a string representation of a hexadecimal number
     public static func digest (_ input : NSData, bitlength:Int = 160) -> String {
-        return digest(input, bitlength: bitlength).toHexString()
+        return ConvertUtil.toHexString(digest(input, bitlength: bitlength).bytes)
     }
     
     // Takes a string representation of a hexadecimal number
@@ -87,8 +87,8 @@ public struct RIPEMD {
     // Takes a string representation of a hexadecimal number and returns a
     // string represenation of the resulting 160 bit hash.
     public static func hexStringDigest (_ input : String, bitlength:Int = 160) -> String {
-        let digest: NSData = hexStringDigest(input, bitlength: bitlength)
-        return digest.toHexString()
+        let digest: Data = hexStringDigest(input, bitlength: bitlength) as Data
+        return ConvertUtil.toHexString(digest.bytes)
     }
     
     // Takes an ASCII string
@@ -106,7 +106,7 @@ public struct RIPEMD {
 //     Takes an ASCII string and returns a hex string represenation of the
 //     resulting 160 bit hash.
     public static func asciiDigest (_ input : String, bitlength:Int = 160) -> String {
-        return asciiDigest(input, bitlength: bitlength).toHexString()
+        return ConvertUtil.toHexString((asciiDigest(input, bitlength: bitlength) as Data).bytes)
     }
     
 }

--- a/NemSwiftTests/Sources/client/NISAPITest.swift
+++ b/NemSwiftTests/Sources/client/NISAPITest.swift
@@ -9,7 +9,6 @@
 import Foundation
 import XCTest
 import APIKit
-import Result
 import NemSwift
 
 //extension Extension where Base: Session {


### PR DESCRIPTION
fixed: #27 Replaced NSData#toHexString to ConvertUtil.toHexString for avoiding not to use NSData#description because the method response format has changed on iOS13 and may be changed on the later version.

